### PR TITLE
Add cmake_src_dir global variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Plugin supports special global variables which are allow to change behaviour of 
  - **`g:cmake_reload_after_save`** if this variable is not equal 0, plugin will reload CMake project after saving CMake files. Default is 0.
  - **`g:cmake_change_build_command`** if this variable is not equal 0, plugin will change the make command. Default is 1.
  - **`g:cmake_build_dir`** allows to set cmake build directory for all build.  Default is ''. If variable is empty the plugin will use the prefix plus build type.
+ - **`g:cmake_src_dir`** allows to set cmake source directory.  Default is '' which evaluates to the current working directory.
  - **`g:cmake_build_dir_prefix`** allows to set cmake build directory prefix. Default is 'cmake-build-'.
  - **`g:cmake_build_target`** set the target name for build. Default is empty and default value depends on CMake Generator
  - **`g:make_arguments`** allows to set custom parameters for make command. Default is empty. If variable is empty, plugin launches `make` without arguments.

--- a/autoload/cmake4vim.vim
+++ b/autoload/cmake4vim.vim
@@ -62,7 +62,7 @@ function! cmake4vim#GenerateCMake(...) abort
 
     " For old CMake version need to change the directory to generate CMake project
     " -B option was introduced only in CMake 3.13
-    let l:src_dir = getcwd()
+    let l:src_dir = utils#cmake#findSrcDir()
     if !utils#cmake#verNewerOrEq([3, 13])
         " Change work directory
         silent exec 'cd' l:build_dir

--- a/autoload/utils/cmake.vim
+++ b/autoload/utils/cmake.vim
@@ -49,6 +49,13 @@ function! s:detectCMakeBuildDir() abort
     let l:build_type = s:detectCMakeBuildType()
     return g:cmake_build_dir_prefix . l:build_type
 endfunction
+
+function! s:detectCMakeSrcDir() abort
+    if g:cmake_src_dir !=# ''
+        return g:cmake_src_dir
+    endif
+    return getcwd()
+endfunction
 " }}} Private functions "
 
 " Returns the list of default CMake build types
@@ -111,6 +118,7 @@ endfunction
 " Additional cmake arguments can be passed as arguments of this function
 function! utils#cmake#getCMakeGenerationCommand(...) abort
     let l:build_dir = utils#cmake#findBuildDir()
+    let l:src_dir = utils#cmake#findSrcDir()
     let l:cmake_args = []
 
     " Set build type
@@ -143,6 +151,7 @@ function! utils#cmake#getCMakeGenerationCommand(...) abort
     " CMake -B option was introduced in the 3.13 version
     if utils#cmake#verNewerOrEq([3, 13])
         let l:cmake_cmd .= ' -B ' . utils#fs#fnameescape(l:build_dir)
+        let l:cmake_cmd .= ' -S ' . utils#fs#fnameescape(l:src_dir)
     else
         let l:cmake_cmd .= ' ' . utils#fs#fnameescape(getcwd())
     endif
@@ -159,6 +168,15 @@ function! utils#cmake#findBuildDir() abort
     " Get cmake information
     call utils#cmake#common#getInfo(l:build_dir)
     return l:build_dir
+endfunction
+
+" Check that src directory exists
+function! utils#cmake#findSrcDir() abort
+    let l:src_dir = finddir(s:detectCMakeSrcDir(), getcwd().';.')
+    if l:src_dir !=# ''
+        let l:src_dir = fnamemodify(l:src_dir, ':p:h')
+    endif
+    return l:src_dir
 endfunction
 
 " Returs the path to build directory if directory was found and returns empty string in other case.

--- a/doc/cmake4vim.txt
+++ b/doc/cmake4vim.txt
@@ -63,6 +63,10 @@ VARIABLES                                                      *cmake-variables*
                                     If variable is empty plugin uses build
                                     directory prefix plus the build type.
 
+*g:cmake_src_dir*                     allows to set cmake source directory.
+                                    Default is '' which evaluates to the
+                                    current working directory.
+
 *g:cmake_build_dir_prefix*            allows to set cmake build directory prefix.
                                     Default is 'cmake-build-'.
 

--- a/plugin/cmake4vim.vim
+++ b/plugin/cmake4vim.vim
@@ -38,6 +38,9 @@ endif
 if !exists('g:cmake_build_dir')
     let g:cmake_build_dir = ''
 endif
+if !exists('g:cmake_src_dir')
+    let g:cmake_src_dir = ''
+endif
 if !exists('g:cmake_build_dir_prefix')
     let g:cmake_build_dir_prefix = 'cmake-build-'
 endif

--- a/test/tests/basic/change_cmake_file.vader
+++ b/test/tests/basic/change_cmake_file.vader
@@ -32,6 +32,7 @@ Before:
     let g:make_arguments=""
     let g:cmake_build_target="all"
     let g:cmake_build_dir=""
+    let g:cmake_src_dir=""
     let g:cmake_change_build_command=1
     let g:cmake_reload_after_save=0
     let g:cmake_build_dir_prefix="cmake-build-"

--- a/test/tests/basic/cmake_info.vader
+++ b/test/tests/basic/cmake_info.vader
@@ -32,6 +32,7 @@ Before:
     let g:make_arguments=""
     let g:cmake_build_target="all"
     let g:cmake_build_dir=""
+    let g:cmake_src_dir=""
     let g:cmake_change_build_command=1
     let g:cmake_reload_after_save=0
     let g:cmake_build_dir_prefix="cmake-build-"

--- a/test/tests/basic/generate_cmake_project.vader
+++ b/test/tests/basic/generate_cmake_project.vader
@@ -32,6 +32,7 @@ Before:
     let g:make_arguments=""
     let g:cmake_build_target="all"
     let g:cmake_build_dir=""
+    let g:cmake_src_dir=""
     let g:cmake_change_build_command=1
     let g:cmake_reload_after_save=0
     let g:cmake_build_dir_prefix="cmake-build-"
@@ -183,4 +184,17 @@ Execute (Call prepare file API after project generation):
     if isdirectory("cmake-build-Release/.cmake/api/v1/reply")
         silent call utils#cmake#fileapi#prepare('cmake-build-Release')
         Assert !isdirectory("cmake-build-Release/.cmake/api/v1/reply"), "Reply directory shouldn't exist"
+    endif
+
+Execute (Generate cmake project in custom source folder):
+    if utils#cmake#verNewerOrEq([3, 13])
+        Assert !isdirectory("cmake-build-Release"), "Build directory shouldn't exist"
+        let g:cmake_src_dir='test proj'
+        cd ..
+        Assert isdirectory(g:cmake_src_dir), "Source directory should exist"
+        silent CMake
+        Assert filereadable("cmake-build-Release/CMakeCache.txt"), "CMakeCache.txt should be generated"
+        silent call RemoveFile("compile_commands.json")
+        silent call RemoveCMakeDirs()
+        cd test\ proj
     endif

--- a/test/tests/basic/plugin_initialization.vader
+++ b/test/tests/basic/plugin_initialization.vader
@@ -50,6 +50,7 @@ Execute (Check default initialization):
         endif
     endif
     AssertEqual g:cmake_build_dir, ""
+    AssertEqual g:cmake_src_dir, ""
     AssertEqual g:cmake_build_dir_prefix, "cmake-build-"
     AssertEqual g:cmake_change_build_command, 1
     AssertEqual g:cmake_reload_after_save, 0


### PR DESCRIPTION
It's set to the cwd by default. This allows a user to override this by
choosing an arbitrary cmake top-level directory.

Just my local hack to get it working for a project in which it's not practical for me that the top level `CMakeLists.txt` is also where my cwd is. I believe this type of flexibility is important and it's something that's missing from all cmake plugins I've seen.

Feel free to give any suggestions/corrections.