### PR TITLE
fix CMakeClean changing g:cmake_build_target

### DIFF
--- a/autoload/cmake4vim.vim
+++ b/autoload/cmake4vim.vim
@@ -109,7 +109,9 @@ function! cmake4vim#CleanCMake() abort
         return
     endif
 
+    let l:current_cmake_target = g:cmake_build_target
     call cmake4vim#CMakeBuild(l:clean_target)
+    call cmake4vim#SelectTarget(l:current_cmake_target)
 endfunction
 
 " Returns all CMake targets


### PR DESCRIPTION
When calling `:CMakeClean` I don't want my target to be set to `clean` so I have to set it back manually.

This causes problems when using `:CMakeRun` since it tries to run the `clean` target and it doesn't exist.