### PR TITLE
add RunTarget arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Plugin supports special global variables which are allow to change behaviour of 
  - **`g:cmake_src_dir`** allows to set cmake source directory.  Default is '' which evaluates to the current working directory.
  - **`g:cmake_build_dir_prefix`** allows to set cmake build directory prefix. Default is 'cmake-build-'.
  - **`g:cmake_build_target`** set the target name for build. Default is empty and default value depends on CMake Generator
+ - **`g:cmake_run_target_args`** set the arguments for running the current target, e.g. '--gtest_filter=TestSuite.\*'. Default is empty
  - **`g:make_arguments`** allows to set custom parameters for make command. Default is empty. If variable is empty, plugin launches `make` without arguments.
  - **`g:cmake_project_generator`** allows to set the project generator for build scripts. Default is empty.
  - **`g:cmake_install_prefix`** allows to change **`-DCMAKE_INSTALL_PREFIX`**. Default is empty.

--- a/autoload/cmake4vim.vim
+++ b/autoload/cmake4vim.vim
@@ -187,7 +187,7 @@ function! cmake4vim#RunTarget(...) abort
 
     let l:exec_path = utils#cmake#getBinaryPath()
     if strlen(l:exec_path)
-        call utils#common#executeCommand(join([l:exec_path] + a:000) . ' ' . g:cmake_run_target_args, ' ')
+        call utils#common#executeCommand(join([l:exec_path] + a:000 + [g:cmake_run_target_args], ' '))
     else
         let v:errmsg = 'Executable "' . g:cmake_build_target . '" was not found'
         call utils#common#Warning(v:errmsg)

--- a/autoload/cmake4vim.vim
+++ b/autoload/cmake4vim.vim
@@ -187,7 +187,7 @@ function! cmake4vim#RunTarget(...) abort
 
     let l:exec_path = utils#cmake#getBinaryPath()
     if strlen(l:exec_path)
-        call utils#common#executeCommand(join([l:exec_path] + a:000, ' '))
+        call utils#common#executeCommand(join([l:exec_path] + a:000) . ' ' . g:cmake_run_target_args, ' ')
     else
         let v:errmsg = 'Executable "' . g:cmake_build_target . '" was not found'
         call utils#common#Warning(v:errmsg)

--- a/plugin/cmake4vim.vim
+++ b/plugin/cmake4vim.vim
@@ -59,6 +59,9 @@ endif
 if !exists('g:cmake_usr_args')
     let g:cmake_usr_args = ''
 endif
+if !exists('g:cmake_run_target_args')
+    let g:cmake_run_target_args = ''
+endif
 
 " Optional variable allow to specify the build executor
 " Possible values: 'job', 'dispatch', 'system', ''


### PR DESCRIPTION
Most of the times you need to pass some sort of arguments or flags to the current target.

This PR introduces the `cmake_run_target_args` variable that allows you to do just that.