### PR TITLE
Use buffer as a job output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 test/tmp
 .DS_Store
 *.swp
+*.swo

--- a/autoload/utils/cmake/fileapi.vim
+++ b/autoload/utils/cmake/fileapi.vim
@@ -16,11 +16,7 @@ function! s:getReplyFolder(build_dir) abort
 endfunction
 
 function! s:createFile(filename, content) abort
-    new
-    setlocal buftype=nofile bufhidden=hide noswapfile nobuflisted
-    put=a:content
-    execute 'w! ' a:filename
-    q
+    silent call writefile( [ a:content ], a:filename )
 endfunction
 
 function! s:createQuery() abort

--- a/autoload/utils/common.vim
+++ b/autoload/utils/common.vim
@@ -10,8 +10,11 @@ function! utils#common#executeCommand(cmd, ...) abort
         silent! cclose
         call utils#exec#dispatch#run(a:cmd, l:errFormat)
     elseif (g:cmake_build_executor ==# 'job') || (g:cmake_build_executor ==# '' && ((has('job') && has('channel')) || has('nvim')))
+        " job#run behaves differently if the qflist is open or closed
         call utils#exec#job#run(a:cmd, l:errFormat)
     else
+        " Close quickfix list to discard custom error format
+        silent! cclose
         call utils#exec#system#run(a:cmd, l:errFormat)
     endif
 endfunction

--- a/autoload/utils/common.vim
+++ b/autoload/utils/common.vim
@@ -3,11 +3,11 @@
 
 " Executes the command
 function! utils#common#executeCommand(cmd, ...) abort
-    " Close quickfix list in order to don't save custom error format
-    silent! cclose
     let l:errFormat = get(a:, 1, '')
 
     if (g:cmake_build_executor ==# 'dispatch') || (g:cmake_build_executor ==# '' && exists(':Dispatch'))
+        " Close quickfix list to discard custom error format
+        silent! cclose
         call utils#exec#dispatch#run(a:cmd, l:errFormat)
     elseif (g:cmake_build_executor ==# 'job') || (g:cmake_build_executor ==# '' && ((has('job') && has('channel')) || has('nvim')))
         call utils#exec#job#run(a:cmd, l:errFormat)

--- a/autoload/utils/exec/job.vim
+++ b/autoload/utils/exec/job.vim
@@ -106,10 +106,11 @@ function! s:createJobBuf() abort
     setlocal bufhidden=hide buftype=nofile buflisted nolist
     setlocal noswapfile nowrap nomodifiable
     nmap <buffer> <C-c> :call utils#exec#job#stop()<CR>
+    let l:bufnum = winbufnr(0)
     if !l:cursor_was_in_quickfix
         wincmd p
     endif
-    return winbufnr(0)
+    return l:bufnum
 endfunction
 " }}} Private functions "
 
@@ -129,12 +130,12 @@ function! utils#exec#job#stop() abort
     call s:createQuickFix()
     call s:closeBuffer()
     copen
-    echom 'Job is canceled!'
+    call utils#common#Warning('Job is cancelled!')
 endfunction
 
 function! utils#exec#job#run(cmd, err_fmt) abort
-    let l:openbufnr = bufnr(s:cmake4vim_buf)
-    if !empty(s:cmake4vim_job) || l:openbufnr != -1
+    " if there is a job or if the buffer is open, abort
+    if !empty(s:cmake4vim_job) || bufnr(s:cmake4vim_buf) != -1
         call utils#common#Warning('Async execute is already running')
         return -1
     endif

--- a/autoload/utils/exec/job.vim
+++ b/autoload/utils/exec/job.vim
@@ -69,7 +69,7 @@ function! s:vimClose(channel) abort
     call s:closeBuffer()
     let s:cmake4vim_job = {}
 
-    cwindow
+    copen
     cbottom
 endfunction
 

--- a/autoload/utils/exec/job.vim
+++ b/autoload/utils/exec/job.vim
@@ -69,7 +69,7 @@ function! s:vimClose(channel) abort
     call s:closeBuffer()
     let s:cmake4vim_job = {}
 
-    copen
+    cwindow
     cbottom
 endfunction
 
@@ -94,8 +94,11 @@ function! s:nVimExit(job_id, data, event) abort
 endfunction
 
 function! s:createJobBuf() abort
-    let l:in_quickfix = getwininfo(win_getid())[0]['quickfix']
-    if l:in_quickfix
+    let l:cursor_was_in_quickfix = getwininfo(win_getid())[0]['quickfix']
+    " qflist is open somewhere
+    if !empty(filter(range(1, winnr('$')), 'getwinvar(v:val, "&ft") ==# "qf"'))
+        " move the cursor there
+        copen
         silent execute 'edit ' . s:cmake4vim_buf
     else
         silent execute 'belowright 10split ' . s:cmake4vim_buf
@@ -103,11 +106,10 @@ function! s:createJobBuf() abort
     setlocal bufhidden=hide buftype=nofile buflisted nolist
     setlocal noswapfile nowrap nomodifiable
     nmap <buffer> <C-c> :call utils#exec#job#stop()<CR>
-    let l:bufnum = winbufnr(0)
-    if !l:in_quickfix
+    if !l:cursor_was_in_quickfix
         wincmd p
     endif
-    return l:bufnum
+    return winbufnr(0)
 endfunction
 " }}} Private functions "
 

--- a/autoload/utils/exec/job.vim
+++ b/autoload/utils/exec/job.vim
@@ -69,7 +69,7 @@ function! s:vimClose(channel) abort
     call s:closeBuffer()
     let s:cmake4vim_job = {}
 
-    copen
+    cwindow
     cbottom
 endfunction
 

--- a/autoload/utils/exec/job.vim
+++ b/autoload/utils/exec/job.vim
@@ -132,9 +132,7 @@ function! utils#exec#job#stop() abort
     echom 'Job is canceled!'
 endfunction
 
-" Use job
 function! utils#exec#job#run(cmd, err_fmt) abort
-    " Create a new quickfix
     let l:openbufnr = bufnr(s:cmake4vim_buf)
     if !empty(s:cmake4vim_job) || l:openbufnr != -1
         call utils#common#Warning('Async execute is already running')

--- a/test/tests/build/job_run.vader
+++ b/test/tests/build/job_run.vader
@@ -41,6 +41,7 @@ Before:
     silent on
 
 After:
+    silent cclose
     silent call RemoveFile("compile_commands.json")
     silent call RemoveCMakeDirs()
     cd ..

--- a/test/tests/build/job_run.vader
+++ b/test/tests/build/job_run.vader
@@ -36,7 +36,7 @@ Before:
     let g:cmake_build_dir_prefix="cmake-build-"
     let g:cmake_build_executor = 'job'
     let g:cmake_variants = {}
-    let g:cmake_ctest_args = []
+    let g:cmake_ctest_args = ''
     " Use on in order to close all windows and avoid E36 error
     silent on
 


### PR DESCRIPTION
This should fix #66.

The `s:appendLine` in `vim` is not necessary since `job` can write directly to buffer, but `neovim` can't.