### PR TITLE
Fixed sporadic crash in CI

### DIFF
--- a/autoload/utils/exec/job.vim
+++ b/autoload/utils/exec/job.vim
@@ -39,7 +39,10 @@ function! s:closeBuffer() abort
         exec l:winnr.'wincmd c'
     endif
     if l:bufnr != -1
-        silent exec 'bwipeout ' . escape(bufname(l:bufnr), ' \')
+        try
+            silent exec 'bwipeout ' . escape(bufname(l:bufnr), ' \')
+        catch
+        endtry
     endif
 endfunction
 


### PR DESCRIPTION
```
(X) Vim(bwipeout):E93: More than one match for cmake4vim_execute
      > function <SNR>293_nVimExit[5]..<SNR>293_closeBuffer, line 9
```