### PR TITLE
Keep alternate file when running job executor

### DIFF
--- a/autoload/utils/exec/job.vim
+++ b/autoload/utils/exec/job.vim
@@ -85,9 +85,9 @@ function! s:createJobBuf() abort
     if !empty(filter(range(1, winnr('$')), 'getwinvar(v:val, "&ft") ==# "qf"'))
         " move the cursor there
         copen
-        silent execute 'edit ' . s:cmake4vim_buf
+        silent execute 'keepalt edit ' . s:cmake4vim_buf
     else
-        silent execute 'belowright 10split ' . s:cmake4vim_buf
+        silent execute 'keepalt belowright 10split ' . s:cmake4vim_buf
     endif
     setlocal bufhidden=hide buftype=nofile buflisted nolist
     setlocal noswapfile nowrap nomodifiable

--- a/test/tests/build/job.vader
+++ b/test/tests/build/job.vader
@@ -107,3 +107,13 @@ Execute ([Job executor] Run 2 jobs at once):
     silent call utils#exec#job#stop()
     AssertEqual bufnr('cmake4vim_execute'), -1
 
+Execute ([Job executor] Run job and don't mess up the alternate file):
+    silent edit first.txt
+    silent edit second.txt
+    AssertEqual bufname("#"), "first.txt"
+    silent call utils#exec#job#run('sleep 1', '')
+    AssertEqual bufname("#"), "first.txt"
+    sleep 2
+    copen
+    cclose
+    AssertEqual bufname("#"), "first.txt"


### PR DESCRIPTION
The `#` buffer was being changed when starting a `job`, and when the `job` finished it `bwipeout`'d the buffer so the `alternate file` got cleared. This fixes it. 