### PR TITLE
Make cmake4vim_execute follow output in neovim

### DIFF
--- a/autoload/utils/exec/job.vim
+++ b/autoload/utils/exec/job.vim
@@ -52,6 +52,7 @@ function! s:nVimOut(job_id, data, event) abort
     call setbufvar(l:bufnr, '&modifiable', 1)
     for val in filter(a:data, '!empty(v:val)')
         silent call appendbufline(l:bufnr, '$', trim(val, "\r\n"))
+        normal! G
     endfor
     call setbufvar(l:bufnr, '&modifiable', 0)
 endfunction


### PR DESCRIPTION
This should solve [#114](https://github.com/ilyachur/cmake4vim/issues/114).