### PR TITLE
Keep quickfix opened for CMakeRun, CTest and etc.

### DIFF
--- a/autoload/cmake4vim.vim
+++ b/autoload/cmake4vim.vim
@@ -73,7 +73,7 @@ function! cmake4vim#GenerateCMake(...) abort
         silent exec 'cd' l:build_dir
     endif
     " Generates CMake project
-    call utils#common#executeCommand(l:cmake_cmd, s:getCMakeErrorFormat())
+    call utils#common#executeCommand(l:cmake_cmd, 0, s:getCMakeErrorFormat())
     if !utils#cmake#verNewerOrEq([3, 13])
         " Change work directory to old work directory
         silent exec 'cd' l:cw_dir
@@ -155,7 +155,7 @@ function! cmake4vim#CMakeBuild(...) abort
     " Select target
     let l:result = cmake4vim#SelectTarget(l:cmake_target)
     " Build
-    call utils#common#executeCommand(l:result)
+    call utils#common#executeCommand(l:result, 0)
 endfunction
 
 " Run Ctest
@@ -170,7 +170,7 @@ function! cmake4vim#CTest(bang, ...) abort
     silent exec 'cd' l:build_dir
     let l:cmd = printf('ctest %s %s', a:bang ? '' : g:cmake_ctest_args, join( a:000 ) )
     " Run
-    call utils#common#executeCommand(l:cmd)
+    call utils#common#executeCommand(l:cmd, 1)
     " Change work directory to old work directory
     silent exec 'cd' l:cw_dir
 endfunction
@@ -209,7 +209,7 @@ function! cmake4vim#RunTarget(bang, ...) abort
     let l:conf = { g:cmake_build_target : { 'app': l:exec_path, 'args': l:args } }
     call utils#config#vimspector#updateConfig(l:conf)
     if strlen(l:exec_path)
-        call utils#common#executeCommand(join([utils#fs#fnameescape(l:exec_path)] + l:args, ' '))
+        call utils#common#executeCommand(join([utils#fs#fnameescape(l:exec_path)] + l:args, ' '), 1)
     else
         let v:errmsg = 'Executable "' . g:cmake_build_target . '" was not found'
         call utils#common#Warning(v:errmsg)

--- a/autoload/utils/common.vim
+++ b/autoload/utils/common.vim
@@ -18,21 +18,22 @@ endfunction
 " }}} Private functions "
 
 " Executes the command
-function! utils#common#executeCommand(cmd, ...) abort
+function! utils#common#executeCommand(cmd, open_result, ...) abort
     let l:errFormat = get(a:, 1, '')
+    call utils#common#Warning(l:errFormat)
 
     let l:cmd = s:add_noglob(a:cmd)
     if (g:cmake_build_executor ==# 'dispatch') || (g:cmake_build_executor ==# '' && exists(':Dispatch'))
         " Close quickfix list to discard custom error format
         silent! cclose
-        call utils#exec#dispatch#run(l:cmd, l:errFormat)
+        call utils#exec#dispatch#run(l:cmd, a:open_result, l:errFormat)
     elseif (g:cmake_build_executor ==# 'job') || (g:cmake_build_executor ==# '' && ((has('job') && has('channel')) || has('nvim')))
         " job#run behaves differently if the qflist is open or closed
-        call utils#exec#job#run(l:cmd, l:errFormat)
+        call utils#exec#job#run(l:cmd, a:open_result, l:errFormat)
     else
         " Close quickfix list to discard custom error format
         silent! cclose
-        call utils#exec#system#run(l:cmd, l:errFormat)
+        call utils#exec#system#run(l:cmd, a:open_result, l:errFormat)
     endif
 endfunction
 

--- a/autoload/utils/exec/dispatch.vim
+++ b/autoload/utils/exec/dispatch.vim
@@ -2,7 +2,7 @@
 " Maintainer:   Ilya Churaev <https://github.com/ilyachur>
 
 " Use dispatch to make command
-function! utils#exec#dispatch#run(cmd, errFormat) abort
+function! utils#exec#dispatch#run(cmd, open_qf, errFormat) abort
     let l:old_error = &l:errorformat
     if a:errFormat !=# ''
         let &l:errorformat = a:errFormat

--- a/autoload/utils/exec/job.vim
+++ b/autoload/utils/exec/job.vim
@@ -39,11 +39,15 @@ function! s:createQuickFix() abort
 endfunction
 
 function! s:vimClose(channel) abort
+    let l:open_qf = s:cmake4vim_job['open_qf']
     call s:createQuickFix()
     call s:closeBuffer()
-    let s:cmake4vim_job = {}
 
-    silent cwindow
+    if l:open_qf == 0
+        silent cwindow
+    else
+        copen
+    endif
     cbottom
 endfunction
 
@@ -62,6 +66,8 @@ function! s:nVimExit(job_id, data, event) abort
         return
     endif
 
+    let l:open_qf = s:cmake4vim_job['open_qf']
+
     " just to be sure all messages were processed
     sleep 100m
 
@@ -73,7 +79,7 @@ function! s:nVimExit(job_id, data, event) abort
 
     call s:createQuickFix()
     call s:closeBuffer()
-    if a:data != 0
+    if a:data != 0 || l:open_qf != 0
         copen
     endif
 endfunction
@@ -120,7 +126,7 @@ function! utils#exec#job#stop() abort
     call utils#common#Warning('Job is cancelled!')
 endfunction
 
-function! utils#exec#job#run(cmd, err_fmt) abort
+function! utils#exec#job#run(cmd, open_qf, err_fmt) abort
     " if there is a job or if the buffer is open, abort
     if !empty(s:cmake4vim_job) || bufnr(s:cmake4vim_buf) != -1
         call utils#common#Warning('Async execute is already running')
@@ -144,7 +150,7 @@ function! utils#exec#job#run(cmd, err_fmt) abort
                     \ 'err_modifiable' : 0,
                     \ })
     endif
-    let s:cmake4vim_job = { 'job': l:job, 'cmd': a:cmd }
+    let s:cmake4vim_job = { 'job': l:job, 'cmd': a:cmd, 'open_qf': a:open_qf }
     if !has('nvim')
        let s:cmake4vim_job['channel'] = job_getchannel(l:job)
     endif

--- a/autoload/utils/exec/job.vim
+++ b/autoload/utils/exec/job.vim
@@ -39,10 +39,7 @@ function! s:createQuickFix() abort
 endfunction
 
 function! s:vimClose(channel) abort
-    let l:open_qf = 0
-    if has_key(s:cmake4vim_job, 'open_qf')
-        let l:open_qf = s:cmake4vim_job['open_qf']
-    endif
+    let l:open_qf = get(s:cmake4vim_job, 'open_qf', 0)
 
     call s:createQuickFix()
     call s:closeBuffer()

--- a/autoload/utils/exec/job.vim
+++ b/autoload/utils/exec/job.vim
@@ -39,7 +39,11 @@ function! s:createQuickFix() abort
 endfunction
 
 function! s:vimClose(channel) abort
-    let l:open_qf = s:cmake4vim_job['open_qf']
+    let l:open_qf = 0
+    if has_key(s:cmake4vim_job, 'open_qf')
+        let l:open_qf = s:cmake4vim_job['open_qf']
+    endif
+
     call s:createQuickFix()
     call s:closeBuffer()
 

--- a/autoload/utils/exec/system.vim
+++ b/autoload/utils/exec/system.vim
@@ -2,15 +2,18 @@
 " Maintainer:   Ilya Churaev <https://github.com/ilyachur>
 
 " Use system
-function! utils#exec#system#run(cmd, errFormat) abort
+function! utils#exec#system#run(cmd, open_qf, errFormat) abort
     let l:old_error = &l:errorformat
     if a:errFormat !=# ''
         let &l:errorformat = a:errFormat
     endif
     let l:s_out = system(a:cmd)
+    let l:ret_code = v:shell_error
     cgetexpr l:s_out
     call setqflist( [], 'a', { 'title' : a:cmd } )
-    copen
+    if a:open_qf == 1 || l:ret_code != 0
+        copen
+    endif
     if a:errFormat !=# ''
         let &l:errorformat = l:old_error
     endif

--- a/test/tests/build/job.vader
+++ b/test/tests/build/job.vader
@@ -97,13 +97,13 @@ Execute ([Job executor] Check job cancel command without run):
 
 Execute ([Job executor] Check job cancel command):
     AssertEqual bufnr('cmake4vim_execute'), -1
-    silent call utils#exec#job#run('sleep 10', '')
+    silent call utils#exec#job#run('sleep 10', 1, '')
     silent call utils#exec#job#stop()
     AssertEqual bufnr('cmake4vim_execute'), -1
 
 Execute ([Job executor] Run 2 jobs at once):
-    silent call utils#exec#job#run('sleep 10', '')
-    let ret_code = utils#exec#job#run('sleep 10', '')
+    silent call utils#exec#job#run('sleep 10', 1, '')
+    let ret_code = utils#exec#job#run('sleep 10', 1, '')
     AssertEqual ret_code, -1
     silent call utils#exec#job#stop()
     AssertEqual bufnr('cmake4vim_execute'), -1
@@ -112,7 +112,7 @@ Execute ([Job executor] Run job and don't mess up the alternate file):
     silent edit first.txt
     silent edit second.txt
     AssertEqual bufname("#"), "first.txt"
-    silent call utils#exec#job#run('sleep 1', '')
+    silent call utils#exec#job#run('sleep 1', 1, '')
     AssertEqual bufname("#"), "first.txt"
     sleep 2
     copen

--- a/test/tests/integration/vimspector.vader
+++ b/test/tests/integration/vimspector.vader
@@ -151,7 +151,7 @@ Execute ([Vimspector] Run test_app target and change vimspector config):
         AssertEqual config['configurations']['test_app']['configuration']['args'], ['1', '2', '3']
     else
         " WA to skip test
-        call utils#common#executeCommand('echo 1 2 3 F1')
+        call utils#common#executeCommand('echo 1 2 3 F1', 1)
     endif
 
 Expect ([Vimspector] See '1 2 3 F1' result in quickfix):
@@ -182,7 +182,7 @@ Execute ([Vimspector] Run test_app target with vimspector args):
         AssertEqual len(config['configurations']['test_app']['configuration']['args']), 4
     else
         " WA to skip test
-        call utils#common#executeCommand('echo 1 2 3* 4 F1')
+        call utils#common#executeCommand('echo 1 2 3* 4 F1', 1)
     endif
 
 Expect ([Vimspector] See '1 2 3* 4 F1' result in quickfix):
@@ -213,7 +213,7 @@ Execute ([Vimspector] Run test_app target with reset vimspector args):
         AssertEqual len(config['configurations']['test_app']['configuration']['args']), 0
     else
         " WA to skip test
-        call utils#common#executeCommand('echo F1')
+        call utils#common#executeCommand('echo F1', 1)
     endif
 
 Expect ([Vimspector] See 'F1' result in quickfix):

--- a/test/tests/run/run_target.vader
+++ b/test/tests/run/run_target.vader
@@ -104,9 +104,8 @@ Execute ([CMakeRun] Run test_app target and open quickfix):
         silent CMakeRun
     else
         " WA to skip test
-        call utils#common#executeCommand('echo F1')
+        call utils#common#executeCommand('echo F1', 1)
     endif
-    copen
     let output = getqflist()
     AssertEqual 'F1', output[0]['text']
     AssertEqual    1, len(output)
@@ -126,7 +125,7 @@ Execute ([CMakeRun] Run test_app target with runtime output and open quickfix):
         silent CMakeRun 123
     else
         " WA to skip test
-        call utils#common#executeCommand('echo 123 F1')
+        call utils#common#executeCommand('echo 123 F1', 1)
     endif
     let output = getqflist()
     AssertEqual        1, len(output)
@@ -140,7 +139,7 @@ Execute ([CMakeRun] Run test_app target with mask arguments):
         silent CMakeRun --gtest_filter=Test*
     else
         " WA to skip test
-        call utils#common#executeCommand('echo --gtest_filter=Test* F1')
+        call utils#common#executeCommand('echo --gtest_filter=Test* F1', 1)
     endif
     let output = getqflist()
     AssertEqual 1, len(output)
@@ -160,7 +159,7 @@ Execute ([CMakeRun] Run test_app target with mask arguments with job executor):
         AssertEqual bufnr('cmake4vim_execute'), -1
     else
         " WA to skip test
-        call utils#common#executeCommand('echo --gtest_filter=Test* F1')
+        call utils#common#executeCommand('echo --gtest_filter=Test* F1', 1)
     endif
     let output = getqflist()
     Assert 1 == len(output), output


### PR DESCRIPTION
Enable this functionality only for `job` and `system` executors