### PR TITLE
Print exception when reading vimspector config

### DIFF
--- a/autoload/utils/config/vimspector.vim
+++ b/autoload/utils/config/vimspector.vim
@@ -11,6 +11,7 @@ function! s:readVimspectorConfig() abort
     try
         return json_decode(join(readfile(s:getVimspectorConfig()), ''))
     catch
+        call utils#common#Warning( 'Exception reading vimspector config: ' . v:exception )
         return {}
     endtry
 endfunction


### PR DESCRIPTION
I kept getting `Unsupported vimspector format`, but had no idea what the error was, so this might help someone else too.

I hope this doesn't break the tests...