### PR TITLE
Remove ninja targets starting with '/'

### DIFF
--- a/autoload/utils/gen/ninja.vim
+++ b/autoload/utils/gen/ninja.vim
@@ -18,7 +18,7 @@ endfunction
 
 " Returns the list of targets for CMake generator
 function! utils#gen#ninja#getTargets(build_dir) abort
-    let l:res = split(system(g:cmake_executable . ' --build ' . utils#fs#fnameescape(a:build_dir) . ' --target help'), "\n")
+    let l:res = split(system(printf('%s --build %s --target help', g:cmake_executable, utils#fs#fnameescape(a:build_dir))), "\n")
     let l:list_targets = []
     let l:targets_found = 0
     for l:value in l:res
@@ -31,6 +31,9 @@ function! utils#gen#ninja#getTargets(build_dir) abort
 
         if l:value !=# ''
             let l:target = split(l:value, ':')[0]
+            if stridx(l:target, '/') == 0
+                continue
+            endif
             let l:list_targets += [l:target]
         endif
     endfor
@@ -39,7 +42,7 @@ endfunction
 
 " Returns the cmake build command for CMake generator
 function! utils#gen#ninja#getBuildCommand(build_dir, target, make_arguments) abort
-    let l:cmd = g:cmake_executable . ' --build ' . utils#fs#fnameescape(a:build_dir) . ' --target ' . a:target . ' -- '
+    let l:cmd = printf('%s --build %s --target %s -- ', g:cmake_executable, utils#fs#fnameescape(a:build_dir), a:target)
     if stridx(a:make_arguments, '-C ') == -1 && a:target !=# utils#gen#ninja#getCleanTarget()
         let l:cmd .= '-C ' . utils#fs#fnameescape(fnamemodify(a:build_dir, ':p:h')) . ' '
     endif


### PR DESCRIPTION
At some point `ninja --target help` started printing absolute paths to targets, so this filters out such targets.

Also I used `printf` because it was more readable.