### PR TITLE
Make job executor buffer open botright

### DIFF
--- a/autoload/utils/exec/job.vim
+++ b/autoload/utils/exec/job.vim
@@ -63,9 +63,9 @@ function! s:vimClose(channel) abort
     call s:createQuickFix()
 
     if l:open_qf == 0
-        silent execute g:cmake_build_executor_height . 'cwindow'
+        silent execute printf( 'botright %dcwindow', g:cmake_build_executor_height )
     else
-        silent execute g:cmake_build_executor_height . 'copen'
+        silent execute printf( 'botright %dcopen', g:cmake_build_executor_height )
     endif
     cbottom
 endfunction
@@ -95,7 +95,7 @@ function! s:nVimExit(job_id, data, event) abort
     endif
     call s:createQuickFix()
     if a:data != 0 || l:open_qf != 0
-        silent execute g:cmake_build_executor_height . 'copen'
+        silent execute printf( 'botright %dcopen', g:cmake_build_executor_height )
     endif
 endfunction
 
@@ -106,10 +106,10 @@ function! s:createJobBuf() abort
     " qflist is open somewhere
     if !empty(filter(range(1, winnr('$')), 'getwinvar(v:val, "&ft") ==# "qf"'))
         " move the cursor there
-        silent execute g:cmake_build_executor_height . 'copen'
+        silent execute printf( 'botright %dcopen', g:cmake_build_executor_height )
         silent execute 'keepalt edit ' . s:cmake4vim_buf
     else
-        silent execute printf('keepalt belowright %dsplit %s', g:cmake_build_executor_height, s:cmake4vim_buf)
+        silent execute printf('keepalt botright %dsplit %s', g:cmake_build_executor_height, s:cmake4vim_buf)
     endif
     setlocal bufhidden=hide buftype=nofile buflisted nolist
     setlocal noswapfile nowrap nomodifiable


### PR DESCRIPTION
Open the buffer for `job build executor` botright so it is _always_ at the bottom, the full width of the screen, instead of just below the right split.