### PR TITLE
Improve CTest run

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ The current version of the plugin supports next commands:
  - **`:CMakeRun!`** Run the current the binary of currently selected target. Command allows to reset previous arguments if plugin reads arguments from [Vimspector](https://github.com/puremourning/vimspector) config.
  - **`:CTest`** run `ctest`. The command allows to specify CTest arguments and default arguments can be set in `g:cmake_ctest_args`
  - **`:CTest!`** same as `:CTest` but ignores `g:cmake_ctest_args`.
+ - **`:CTestCurrent`** same as `:CTest` but run tests with `-R current_cmake_target`.
+ - **`:CTestCurrent!`** same as `:CTest!` but run tests with `-R current_cmake_target`.
 
 #### Integration
 
@@ -103,6 +105,7 @@ The current version of the plugin supports next commands:
 | `(CMakeInfo)`             | `:CMakeInfo`              |
 | `(CMakeRun)`              | `:CMakeRun`               |
 | `(CTest)`                 | `:CTest`                  |
+| `(CTestCurrent)`          | `:CTestCurrent`           |
 | `(CCMake)`                | `:CCMake`                 |
 | `(CMakeCompileSource)`    | `:CMakeCompileSource`     |
 

--- a/autoload/cmake4vim.vim
+++ b/autoload/cmake4vim.vim
@@ -242,7 +242,7 @@ function! cmake4vim#CTest(bang, ...) abort
 endfunction
 
 function! cmake4vim#CTestCurrent(bang, ...) abort
-    let l:args = join(a:000) . ' -R ' . g:cmake_build_target
+    let l:args = printf('%s -R %s',join(a:000), g:cmake_build_target)
     call cmake4vim#CTest(a:bang, l:args)
 endfunction
 

--- a/autoload/cmake4vim.vim
+++ b/autoload/cmake4vim.vim
@@ -225,13 +225,25 @@ function! cmake4vim#CTest(bang, ...) abort
         return
     endif
     let l:cw_dir = getcwd()
-    " Change work directory
-    silent exec 'cd' l:build_dir
-    let l:cmd = printf('ctest %s %s', a:bang ? '' : g:cmake_ctest_args, join( a:000 ) )
+    let l:cmd = 'ctest '
+    if !utils#cmake#verNewerOrEq([3, 20])
+        " Change work directory
+        silent exec 'cd' l:build_dir
+    else
+        let l:cmd .= '--test-dir ' . utils#fs#fnameescape(l:build_dir) . ' '
+    endif
+    let l:cmd = printf('%s %s %s',l:cmd, a:bang ? '' : g:cmake_ctest_args, join(a:000))
     " Run
     call utils#common#executeCommand(l:cmd, 1)
-    " Change work directory to old work directory
-    silent exec 'cd' l:cw_dir
+    if !utils#cmake#verNewerOrEq([3, 20])
+        " Change work directory to old work directory
+        silent exec 'cd' l:cw_dir
+    endif
+endfunction
+
+function! cmake4vim#CTestCurrent(bang, ...) abort
+    let l:args = join(a:000) . ' -R ' . g:cmake_build_target
+    call cmake4vim#CTest(a:bang, l:args)
 endfunction
 
 " Functions allows to switch between build types

--- a/doc/cmake4vim.txt
+++ b/doc/cmake4vim.txt
@@ -61,6 +61,14 @@ COMMANDS                                                        *cmake-commands*
     Runs tests. Ignores g:cmake_ctest_args. You can pass additional ctest
     arguments.
 
+:CTestCurrent[{Args}]                                            *:CTestCurrent*
+    Runs tests for current target (-R cmake_current target).
+    Uses g:cmake_ctest_args. You can pass additional ctest arguments.
+
+:CTestCurrent![{Args}]                                           *:CTestCurrent!*
+    Runs tests for current target (-R cmake_current target).
+    Ignores g:cmake_ctest_args. You can pass additional ctest arguments.
+
 :CCMake                                                                *:CCMake*
     Allows to use *ccmake* command inside vim.
     The command supports next open modes (by default the horizontal mode

--- a/plugin/cmake4vim.vim
+++ b/plugin/cmake4vim.vim
@@ -65,6 +65,7 @@ command!       -nargs=1 -complete=custom,cmake4vim#CompleteBuildType    CMakeSel
 command!       -nargs=1 -complete=custom,cmake4vim#CompleteKit          CMakeSelectKit          call cmake4vim#SelectKit(<f-args>)
 command!       -nargs=? -complete=custom,cmake4vim#CompleteCCMakeModes  CCMake                  call cmake4vim#CCMake(<f-args>)
 command! -bang -nargs=?  CTest              call cmake4vim#CTest(<bang>0, <f-args>)
+command! -bang -nargs=?  CTestCurrent       call cmake4vim#CTestCurrent(<bang>0, <f-args>)
 command!                 CMakeReset         call cmake4vim#ResetCMakeCache()
 command!                 CMakeClean         call cmake4vim#CleanCMake()
 command!                 CMakeInfo          call utils#window#OpenCMakeInfo()

--- a/plugin/cmake4vim.vim
+++ b/plugin/cmake4vim.vim
@@ -82,6 +82,7 @@ nnoremap <silent> <Plug>(CMakeClean)                :call cmake4vim#CleanCMake()
 nnoremap <silent> <Plug>(CMakeInfo)                 :call utils#window#OpenCMakeInfo()<CR>
 nnoremap <silent> <Plug>(CMakeRun)                  :call cmake4vim#RunTarget(0)<CR>
 nnoremap <silent> <Plug>(CTest)                     :call cmake4vim#CTest(0)<CR>
+nnoremap <silent> <Plug>(CTestCurrent)              :call cmake4vim#CTestCurrent(0)<CR>
 nnoremap <silent> <Plug>(CCMake)                    :call cmake4vim#CCMake()<CR>
 nnoremap <silent> <Plug>(CMakeCompileSource)        :call cmake4vim#CompileSource()<CR>
 " }}} Mappings

--- a/test/cmake projects/test proj/tests/CMakeLists.txt
+++ b/test/cmake projects/test proj/tests/CMakeLists.txt
@@ -42,4 +42,4 @@ else()
 endif()
 
 target_link_libraries(${TARGET_NAME} PRIVATE ${GTEST_LIBRARIES} test_lib)
-add_test(NAME unit COMMAND ${TARGET_NAME})
+add_test(NAME ${TARGET_NAME} COMMAND ${TARGET_NAME})

--- a/test/tests/run/ctest.vader
+++ b/test/tests/run/ctest.vader
@@ -130,7 +130,7 @@ Execute ([CTest] CTest with custom args):
         let g:cmake_ctest_args = '-j2 --output-on-failure --verbose'
         silent CTest -R "non-existant_pattern"
         silent copen
-        Assert w:quickfix_title =~# '-j2 --output-on-failure --verbose -R "non-existant_pattern"'
+        Assert w:quickfix_title =~# '-j2 --output-on-failure --verbose -R "non-existant_pattern"', 'Assert ' . w:quickfix_title
         silent cclose
     endif
 
@@ -142,7 +142,20 @@ Execute ([CTest] CTest with custom args and a bang):
         let g:cmake_ctest_args = '-j2 --output-on-failure --verbose'
         silent CTest! -R "non-existant_pattern"
         silent copen
-        Assert w:quickfix_title !~# '-j2 --output-on-failure --verbose'
-        Assert w:quickfix_title =~# '-R "non-existant_pattern"'
+        Assert w:quickfix_title !~# '-j2 --output-on-failure --verbose', 'Assert1 ' . w:quickfix_title
+        Assert w:quickfix_title =~# '-R "non-existant_pattern"', 'Assert2 ' . w:quickfix_title
+        silent cclose
+    endif
+
+Execute ([CTest] CTest for current target):
+    if !has('win32')
+        silent CMakeBuild unit_tests
+        Assert filereadable("cmake-build-Release/app/test_app"), "app should be built"
+        Assert filereadable("cmake-build-Release/tests/unit_tests"), "unit_tests should be built"
+        Assert filereadable("cmake-build-Release/lib/libtest_lib.a"), "test_lib should be built"
+        let g:cmake_ctest_args = ''
+        silent CTestCurrent
+        silent copen
+        Assert w:quickfix_title =~# '-R unit_tests', 'Assert ' . w:quickfix_title
         silent cclose
     endif


### PR DESCRIPTION
- Use modern CMake options to change directory for ctest
- Introduce new command to run ctest for current target (works in case if target name is used as tests name)