### PR TITLE
Introduce vertical split mode for executors

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The current version of the plugin supports next commands:
 
 #### Integration
 
- - **`:CCMake`** allow to use *ccmake* command inside vim. The command supports next open modes: 'vsplit' - vertical mode, 'hsplit' - horizontal mode, 'tab' - open ccmake in the new tab (by default the horizontal mode is used).
+ - **`:CCMake`** allow to use *ccmake* command inside vim. The command supports next open modes: 'vsplit' - vertical mode, 'split' - horizontal mode, 'tab' - open ccmake in the new tab (by default the executor window split mode is used).
 
 #### FZF plugins
 
@@ -141,7 +141,11 @@ The options below allow to change plugin behavior.
     - 'dispatch' uses [vim-dispatch](https://github.com/tpope/vim-dispatch) plugin to asynchronous build
     - 'system' uses synchronous build
     - '' uses automatic detection of supported modes (the priority is `dispatch`, `job`, `term`, `system`)
- - **`g:cmake_build_executor_height`** defines the height (in rows) of the build window and quickfixlist window showing the results. Default is 10.
+ - **`g:cmake_build_executor_window_size`** defines the size of build window and quickfixlist. Default is 10.
+ - **`g:cmake_build_executor_split_mode`** Allows to configure split mode for build window and quickfixlist. Avaulable values are:
+    - 'sp' enables horizontal mode. It is the default value.
+    - 'vsp' enables vertical mode.
+ - **`g:cmake_build_executor_height`** defines the height (in rows) of the build window and quickfixlist window showing the results. **The option was deprecated, please use `let g:cmake_build_executor_window_size=<size>` instead.** Default is 10.
 
 #### Build path
 

--- a/autoload/cmake4vim.vim
+++ b/autoload/cmake4vim.vim
@@ -313,7 +313,7 @@ function! cmake4vim#CCMake(...) abort
     " * empty, h - Open ccmake in horizontal split
     " * v - Open ccmake in vertical split
     " * t - Open ccmake in new tab
-    let l:mode = a:0 ? a:1 : g:cmake_build_executor_split_mode ==# 'sp' ? 'split' : 'vsplit',
+    let l:mode = a:0 ? a:1 : g:cmake_build_executor_split_mode ==# 'sp' ? 'split' : 'vsplit'
     let l:supported_modes = split(cmake4vim#CompleteCCMakeModes(0, 0, 0), '\n')
 
     if index(l:supported_modes, l:mode) == -1
@@ -325,7 +325,7 @@ function! cmake4vim#CCMake(...) abort
     if !has('nvim')
         let l:cmd .= '++close '
     endif
-    let l:cmd .= 'ccmake ' . utils#fs#fnameescape(utils#cmake#getBuildDir())
+    let l:cmd .= 'ccmake -B ' . utils#fs#fnameescape(utils#cmake#getBuildDir())
     if has('nvim')
         let l:modes = { 'split': 'sp ', 'vsplit': 'vsp | ', 'tab': 'tabnew | ' }
     else

--- a/autoload/cmake4vim.vim
+++ b/autoload/cmake4vim.vim
@@ -355,17 +355,11 @@ function! cmake4vim#init() abort
 
     " Optional variable allow to specify the build executor
     " Possible values: 'job', 'dispatch', 'system', 'term', ''
-    let g:cmake_build_executor                =  get(g:, 'cmake_build_executor'           , '')
+    let g:cmake_build_executor                = get(g:, 'cmake_build_executor'            , '')
 
     " Possible values: sp - horizontal mode, vsp - vertical mode
-    let g:cmake_build_executor_split_mode     =  get(g:, 'cmake_build_executor_split_mode', 'sp')
-    if exists('g:cmake_build_executor_height') && g:cmake_build_executor_height !=# '' && !exists('g:cmake_build_executor_window_size')
-        call utils#common#Warning('g:cmake_cxx_compiler option is deprecated and will be removed at the April of 2024 year!' .
-                            \ ' Please use `let g:cmake_build_executor_window_size=<size>` instead.')
-        let g:cmake_build_executor_window_size = g:cmake_build_executor_height
-    else
-        let g:cmake_build_executor_window_size = get(g:, 'cmake_build_executor_window_size', 10)
-    endif
+    let g:cmake_build_executor_split_mode     = get(g:, 'cmake_build_executor_split_mode' , 'sp')
+    let g:cmake_build_executor_window_size    = get(g:, 'cmake_build_executor_window_size', 10)
 
     " Build path
     let g:cmake_build_path_pattern    = get(g:, 'cmake_build_path_pattern'   , ''            )

--- a/autoload/utils/common.vim
+++ b/autoload/utils/common.vim
@@ -117,3 +117,13 @@ function! utils#common#Warning(msg) abort
                 \ echomsg a:msg |
                 \ echohl None
 endfunction
+
+" Resolve deprecated variables
+function! utils#common#getWindowSize() abort
+    if exists('g:cmake_build_executor_height') && g:cmake_build_executor_height !=# ''
+        call utils#common#Warning('g:cmake_build_executor_height option is deprecated and will be removed at the April of 2024 year!' .
+                                    \ ' Please use `let g:cmake_build_executor_window_size=<size>` instead.')
+        let g:cmake_build_executor_window_size = g:cmake_build_executor_height
+    endif
+    return g:cmake_build_executor_window_size
+endfunction

--- a/autoload/utils/exec/job.vim
+++ b/autoload/utils/exec/job.vim
@@ -74,9 +74,9 @@ function! s:vimClose(channel) abort
     call s:createQuickFix()
 
     if l:open_qf == 0
-        silent execute printf('%sbotright %d cwindow', g:cmake_build_executor_split_mode ==# 'sp' ? '' : 'vert ',  g:cmake_build_executor_window_size)
+        silent execute printf('%sbotright %d cwindow', g:cmake_build_executor_split_mode ==# 'sp' ? '' : 'vert ', utils#common#getWindowSize())
     else
-        silent execute printf('%sbotright %d copen', g:cmake_build_executor_split_mode ==# 'sp' ? '' : 'vert ',  g:cmake_build_executor_window_size)
+        silent execute printf('%sbotright %d copen', g:cmake_build_executor_split_mode ==# 'sp' ? '' : 'vert ', utils#common#getWindowSize())
     endif
     cbottom
 endfunction
@@ -106,7 +106,7 @@ function! s:nVimExit(job_id, data, event) abort
     endif
     call s:createQuickFix()
     if a:data != 0 || l:open_qf != 0
-        silent execute printf('%sbotright %d copen', g:cmake_build_executor_split_mode ==# 'sp' ? '' : 'vert ',  g:cmake_build_executor_window_size)
+        silent execute printf('%sbotright %d copen', g:cmake_build_executor_split_mode ==# 'sp' ? '' : 'vert ', utils#common#getWindowSize())
     endif
 endfunction
 
@@ -117,10 +117,10 @@ function! s:createJobBuf() abort
     " qflist is open somewhere
     if !empty(filter(range(1, winnr('$')), 'getwinvar(v:val, "&ft") ==# "qf"'))
         " move the cursor there
-    silent execute printf('%sbotright %d copen', g:cmake_build_executor_split_mode ==# 'sp' ? '' : 'vert ',  g:cmake_build_executor_window_size)
+    silent execute printf('%sbotright %d copen', g:cmake_build_executor_split_mode ==# 'sp' ? '' : 'vert ', utils#common#getWindowSize())
         silent execute 'keepalt edit ' . s:cmake4vim_buf
     else
-        silent execute printf('keepalt botright %d %s %s', g:cmake_build_executor_window_size, g:cmake_build_executor_split_mode, s:cmake4vim_buf)
+        silent execute printf('keepalt botright %d %s %s', utils#common#getWindowSize(), g:cmake_build_executor_split_mode, s:cmake4vim_buf)
     endif
     setlocal bufhidden=hide buftype=nofile buflisted nolist
     setlocal noswapfile nowrap nomodifiable
@@ -149,7 +149,7 @@ function! utils#exec#job#stop() abort
     endif
     let s:cmake4vim_jobs_pool = []
     call s:createQuickFix()
-    silent execute printf('%sbotright %d copen', g:cmake_build_executor_split_mode ==# 'sp' ? '' : 'vert ',  g:cmake_build_executor_window_size)
+    silent execute printf('%sbotright %d copen', g:cmake_build_executor_split_mode ==# 'sp' ? '' : 'vert ', utils#common#getWindowSize())
     call utils#common#Warning('Job is cancelled!')
 endfunction
 

--- a/autoload/utils/exec/job.vim
+++ b/autoload/utils/exec/job.vim
@@ -74,9 +74,9 @@ function! s:vimClose(channel) abort
     call s:createQuickFix()
 
     if l:open_qf == 0
-        silent execute printf('botright %dcwindow', g:cmake_build_executor_height)
+        silent execute printf('%sbotright %d cwindow', g:cmake_build_executor_split_mode ==# 'sp' ? '' : 'vert ',  g:cmake_build_executor_window_size)
     else
-        silent execute printf('botright %dcopen', g:cmake_build_executor_height)
+        silent execute printf('%sbotright %d copen', g:cmake_build_executor_split_mode ==# 'sp' ? '' : 'vert ',  g:cmake_build_executor_window_size)
     endif
     cbottom
 endfunction
@@ -106,7 +106,7 @@ function! s:nVimExit(job_id, data, event) abort
     endif
     call s:createQuickFix()
     if a:data != 0 || l:open_qf != 0
-        silent execute printf('botright %dcopen', g:cmake_build_executor_height)
+        silent execute printf('%sbotright %d copen', g:cmake_build_executor_split_mode ==# 'sp' ? '' : 'vert ',  g:cmake_build_executor_window_size)
     endif
 endfunction
 
@@ -117,10 +117,10 @@ function! s:createJobBuf() abort
     " qflist is open somewhere
     if !empty(filter(range(1, winnr('$')), 'getwinvar(v:val, "&ft") ==# "qf"'))
         " move the cursor there
-        silent execute printf('botright %dcopen', g:cmake_build_executor_height)
+    silent execute printf('%sbotright %d copen', g:cmake_build_executor_split_mode ==# 'sp' ? '' : 'vert ',  g:cmake_build_executor_window_size)
         silent execute 'keepalt edit ' . s:cmake4vim_buf
     else
-        silent execute printf('keepalt botright %dsplit %s', g:cmake_build_executor_height, s:cmake4vim_buf)
+        silent execute printf('keepalt botright %d %s %s', g:cmake_build_executor_window_size, g:cmake_build_executor_split_mode, s:cmake4vim_buf)
     endif
     setlocal bufhidden=hide buftype=nofile buflisted nolist
     setlocal noswapfile nowrap nomodifiable
@@ -149,7 +149,7 @@ function! utils#exec#job#stop() abort
     endif
     let s:cmake4vim_jobs_pool = []
     call s:createQuickFix()
-    silent execute g:cmake_build_executor_height . 'copen'
+    silent execute printf('%sbotright %d copen', g:cmake_build_executor_split_mode ==# 'sp' ? '' : 'vert ',  g:cmake_build_executor_window_size)
     call utils#common#Warning('Job is cancelled!')
 endfunction
 

--- a/autoload/utils/exec/system.vim
+++ b/autoload/utils/exec/system.vim
@@ -19,7 +19,7 @@ function! utils#exec#system#run(cmd, open_qf, errFormat) abort
     cgetexpr l:s_out
     call setqflist( [], 'a', { 'title' : a:cmd } )
     if a:open_qf == 1 || l:ret_code != 0
-        execute g:cmake_build_executor_height . 'copen'
+        silent execute printf('%sbotright %d copen', g:cmake_build_executor_split_mode ==# 'sp' ? '' : 'vert ',  g:cmake_build_executor_window_size)
     endif
     if !empty(a:errFormat)
         let &l:errorformat = l:old_error

--- a/autoload/utils/exec/system.vim
+++ b/autoload/utils/exec/system.vim
@@ -19,7 +19,7 @@ function! utils#exec#system#run(cmd, open_qf, errFormat) abort
     cgetexpr l:s_out
     call setqflist( [], 'a', { 'title' : a:cmd } )
     if a:open_qf == 1 || l:ret_code != 0
-        silent execute printf('%sbotright %d copen', g:cmake_build_executor_split_mode ==# 'sp' ? '' : 'vert ',  g:cmake_build_executor_window_size)
+        silent execute printf('%sbotright %d copen', g:cmake_build_executor_split_mode ==# 'sp' ? '' : 'vert ',  utils#common#getWindowSize())
     endif
     if !empty(a:errFormat)
         let &l:errorformat = l:old_error

--- a/autoload/utils/exec/term.vim
+++ b/autoload/utils/exec/term.vim
@@ -48,9 +48,9 @@ function! s:vimClose(channel, status) abort
     call s:createQuickFix()
 
     if l:open_qf == 0
-        silent execute printf('%sbotright %d cwindow', g:cmake_build_executor_split_mode ==# 'sp' ? '' : 'vert ',  g:cmake_build_executor_window_size)
+        silent execute printf('%sbotright %d cwindow', g:cmake_build_executor_split_mode ==# 'sp' ? '' : 'vert ', utils#common#getWindowSize())
     else
-        silent execute printf('%sbotright %d copen', g:cmake_build_executor_split_mode ==# 'sp' ? '' : 'vert ',  g:cmake_build_executor_window_size)
+        silent execute printf('%sbotright %d copen', g:cmake_build_executor_split_mode ==# 'sp' ? '' : 'vert ', utils#common#getWindowSize())
     endif
     cbottom
 
@@ -86,7 +86,7 @@ function! s:nVimExit(job_id, data, event) abort
     call s:createQuickFix()
 
     if a:data != 0 || l:open_qf != 0
-        silent execute printf('%sbotright %d copen', g:cmake_build_executor_split_mode ==# 'sp' ? '' : 'vert ',  g:cmake_build_executor_window_size)
+        silent execute printf('%sbotright %d copen', g:cmake_build_executor_split_mode ==# 'sp' ? '' : 'vert ', utils#common#getWindowSize())
     endif
     if a:data == 0
         silent echon 'Success! ' . l:cmd
@@ -118,7 +118,7 @@ function! utils#exec#term#run(cmd, open_qf, cwd, err_fmt) abort
                 \ 'err_fmt': a:err_fmt
                 \ }
     if has('nvim')
-        execute g:cmake_build_executor_window_size . g:cmake_build_executor_split_mode
+        execute utils#common#getWindowSize() . g:cmake_build_executor_split_mode
         execute 'enew'
         let l:job = termopen(a:cmd, {
                     \ 'on_stdout': function('s:nVimOut'),
@@ -130,18 +130,22 @@ function! utils#exec#term#run(cmd, open_qf, cwd, err_fmt) abort
         let l:termbufnr = bufnr()
     else
         let l:cmd = has('win32') ? a:cmd : [&shell, '-c', a:cmd]
-        silent execute printf('keepalt botright %d %s', g:cmake_build_executor_window_size, g:cmake_build_executor_split_mode)
-        let l:job = term_start(l:cmd, {
+        silent execute printf('keepalt botright %d %s', utils#common#getWindowSize(), g:cmake_build_executor_split_mode)
+        let l:options = {
                     \ 'term_name': l:cmake4vim_term,
                     \ 'exit_cb': function('s:vimClose'),
                     \ 'out_cb': function('s:vimOut'),
                     \ 'term_finish': 'close',
+                    \ g:cmake_build_executor_split_mode ==# 'sp' ? 'term_rows' : 'term_cols': utils#common#getWindowSize(),
                     \ 'out_modifiable' : 0,
                     \ 'err_modifiable' : 0,
                     \ 'norestore': 1,
                     \ 'curwin': 1,
                     \ 'cwd': a:cwd
-                    \ })
+                    \ }
+        call utils#common#Warning(l:options)
+    call utils#common#Warning(g:cmake_build_executor_height)
+        let l:job = term_start(l:cmd, l:options)
     endif
     if has('nvim')
         let s:cmake4vim_term['termbuf'] = l:termbufnr

--- a/autoload/utils/exec/term.vim
+++ b/autoload/utils/exec/term.vim
@@ -143,8 +143,6 @@ function! utils#exec#term#run(cmd, open_qf, cwd, err_fmt) abort
                     \ 'curwin': 1,
                     \ 'cwd': a:cwd
                     \ }
-        call utils#common#Warning(l:options)
-    call utils#common#Warning(g:cmake_build_executor_height)
         let l:job = term_start(l:cmd, l:options)
     endif
     if has('nvim')

--- a/autoload/utils/exec/term.vim
+++ b/autoload/utils/exec/term.vim
@@ -48,9 +48,9 @@ function! s:vimClose(channel, status) abort
     call s:createQuickFix()
 
     if l:open_qf == 0
-        silent execute printf('botright %dcwindow', g:cmake_build_executor_height)
+        silent execute printf('%sbotright %d cwindow', g:cmake_build_executor_split_mode ==# 'sp' ? '' : 'vert ',  g:cmake_build_executor_window_size)
     else
-        silent execute printf('botright %dcopen', g:cmake_build_executor_height)
+        silent execute printf('%sbotright %d copen', g:cmake_build_executor_split_mode ==# 'sp' ? '' : 'vert ',  g:cmake_build_executor_window_size)
     endif
     cbottom
 
@@ -86,7 +86,7 @@ function! s:nVimExit(job_id, data, event) abort
     call s:createQuickFix()
 
     if a:data != 0 || l:open_qf != 0
-        silent execute g:cmake_build_executor_height . 'copen'
+        silent execute printf('%sbotright %d copen', g:cmake_build_executor_split_mode ==# 'sp' ? '' : 'vert ',  g:cmake_build_executor_window_size)
     endif
     if a:data == 0
         silent echon 'Success! ' . l:cmd
@@ -118,7 +118,7 @@ function! utils#exec#term#run(cmd, open_qf, cwd, err_fmt) abort
                 \ 'err_fmt': a:err_fmt
                 \ }
     if has('nvim')
-        execute g:cmake_build_executor_height . 'split'
+        execute g:cmake_build_executor_window_size . g:cmake_build_executor_split_mode
         execute 'enew'
         let l:job = termopen(a:cmd, {
                     \ 'on_stdout': function('s:nVimOut'),
@@ -130,13 +130,12 @@ function! utils#exec#term#run(cmd, open_qf, cwd, err_fmt) abort
         let l:termbufnr = bufnr()
     else
         let l:cmd = has('win32') ? a:cmd : [&shell, '-c', a:cmd]
-        silent execute printf('keepalt botright %dsplit', g:cmake_build_executor_height)
+        silent execute printf('keepalt botright %d %s', g:cmake_build_executor_window_size, g:cmake_build_executor_split_mode)
         let l:job = term_start(l:cmd, {
                     \ 'term_name': l:cmake4vim_term,
                     \ 'exit_cb': function('s:vimClose'),
                     \ 'out_cb': function('s:vimOut'),
                     \ 'term_finish': 'close',
-                    \ 'term_rows': g:cmake_build_executor_height,
                     \ 'out_modifiable' : 0,
                     \ 'err_modifiable' : 0,
                     \ 'norestore': 1,

--- a/autoload/utils/window.vim
+++ b/autoload/utils/window.vim
@@ -27,7 +27,7 @@ function! utils#window#OpenCMakeInfoWindow() abort
     let wcmd = s:cmake_info_win_name
     let s:cmake_info_prev_win_id = winnr()
 
-    silent execute printf('botright %d %s %s', g:cmake_build_executor_window_size, g:cmake_build_executor_split_mode, wcmd)
+    silent execute printf('botright %d %s %s', utils#common#getWindowSize(), g:cmake_build_executor_split_mode, wcmd)
 endfunction
 
 function! utils#window#GotoCMakeInfoWindow() abort

--- a/autoload/utils/window.vim
+++ b/autoload/utils/window.vim
@@ -27,7 +27,7 @@ function! utils#window#OpenCMakeInfoWindow() abort
     let wcmd = s:cmake_info_win_name
     let s:cmake_info_prev_win_id = winnr()
 
-    exe 'silent! botright ' . 30 . 'split ' . wcmd
+    silent execute printf('botright %d %s %s', g:cmake_build_executor_window_size, g:cmake_build_executor_split_mode, wcmd)
 endfunction
 
 function! utils#window#GotoCMakeInfoWindow() abort

--- a/doc/cmake4vim.txt
+++ b/doc/cmake4vim.txt
@@ -77,10 +77,10 @@ COMMANDS                                                        *cmake-commands*
 
 :CCMake                                                                *:CCMake*
     Allows to use *ccmake* command inside vim.
-    The command supports next open modes (by default the horizontal mode
-                                          is used):
+    The command supports next open modes (by default the executor window split
+                                          mode is used):
         * 'vsplit' - vertical mode
-        * 'hsplit' - horizontal mode
+        * 'split' - horizontal mode
         * 'tab' - open ccmake in the new tab
 
 :CMakeCompileSource                                        *:CMakeCompileSource*
@@ -169,8 +169,13 @@ g:cmake_build_executor              allows to force set the build executor.
                                     Available values are 'job', 'term', 'dispatch',
                                     'system' and ''. Default is empty.
 
-g:cmake_build_executor_height       defines the height (in rows) of the
-                                    build window and quickfixlist window showing
+g:cmake_build_executor_split_mode   defines the split mode for executor window.
+                                    'sp' is used by default and means
+                                    horizontal mode.
+                                    Use 'vsp' for vertical split mode.
+
+g:cmake_build_executor_window_size  defines the size of the build window and
+                                    quickfixlist window showing
                                     the results. Default is 10.
 
 g:cmake_vimspector_support          enables support of vimspector config.
@@ -201,5 +206,13 @@ g:cmake_kits                        enables predefined cmake kits in the form
 
 g:cmake_selected_kit                currently selected cmake kit.
                                     Default is empty.
+
+DEPRECATED VARIABLES                                                  *cmake-deprecated-variables*
+
+g:cmake_build_executor_height       defines the height (in rows) of the
+                                    build window and quickfixlist window showing
+                                    the results. Default is 10.
+                                    Will be removed at the April of 2022.
+                                    Please use `let g:cmake_build_executor_window_size=<size>` instead.
 
  vim: tw=79 ts=8 sw=4 sts=4 et ft=help

--- a/test/tests/basic/generate_cmake_project.vader
+++ b/test/tests/basic/generate_cmake_project.vader
@@ -183,3 +183,9 @@ Execute ([CMake generate] Create incorrect folder):
     Assert !isdirectory("custom-folder"), "Build directory shouldn't exist"
     call utils#fs#makeDir('custom-folder')
     Assert !isdirectory("custom-folder"), "Build directory shouldn't exist"
+
+Execute ([CMake generate] Verify deprecated warning):
+    let g:cmake_build_executor_height = 10
+    Assert !isdirectory("cmake-build-Release"), "Build directory shouldn't exist"
+    silent CMake
+    Assert filereadable("cmake-build-Release/CMakeCache.txt"), "CMakeCache.txt should be generated"

--- a/test/tests/integration/ccmake.vader
+++ b/test/tests/integration/ccmake.vader
@@ -10,7 +10,7 @@ After:
     silent call RemoveCMakeDirs()
 
 Execute ([CCMake] Get ccmake modes):
-    let ref_modes = ['hsplit', 'vsplit', 'tab']
+    let ref_modes = ['split', 'vsplit', 'tab']
     let modes = split(cmake4vim#CompleteCCMakeModes(0,0,0), "\n")
     AssertEqual len(modes), len(ref_modes), printf("Number of targets: %d List: %s", len(modes), join(modes))
     AssertEqual ref_modes, modes
@@ -25,7 +25,7 @@ Execute ([CCMake] Run ccmake in default mode):
 Execute ([CCMake] Run ccmake in horizontal mode):
     if !has('win32')
         silent CMake
-        CCMake hsplit
+        CCMake split
     endif
 
 Execute ([CCMake] Run ccmake in vertical mode):

--- a/test/vimrc
+++ b/test/vimrc
@@ -56,6 +56,8 @@ function! ResetPluginOptions()
     let g:cmake_selected_kit = ''
     let g:cmake_kits = {}
     let g:cmake_kits_global_path = ''
+    let g:cmake_build_executor_height = ''
+    let g:cmake_build_executor_window_size = 10
 
     let g:cmake_vimspector_default_configuration = {
                 \ 'adapter': '',


### PR DESCRIPTION
Introduce 2 new options:

- `g:cmake_build_executor_split_mode` - allows to change default mode and open CMake windows in vertical mode. (Available values: 'sp' - horizontal mode, 'vsp' - vertical mode).
- `g:cmake_build_executor_window_size` - replaces the variable `g:cmake_build_executor_height` defines the size of executor window.

Option `g:cmake_build_executor_height` was deprecated and will be removed at the end of April 2024.