### PR TITLE
Fix comment preservation in vimspector config rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ I created this plugin in order to improve integration CMake to the Vim editor. I
 * Supports work with multiple build types
 * For CMake newer than 3.13 the plugin uses the CMake file API
 * Plugin allows to find and run executable file for selected target.
-* Plugin supports [Vimspector](https://github.com/puremourning/vimspector) plugin. Plugin can generate and modify Vimspector configuration file in order to save command line arguments and allows to debug application.
+* Plugin supports [Vimspector](https://github.com/puremourning/vimspector) plugin. Plugin can generate and modify Vimspector configuration file in order to save command line arguments and allows to debug application. `//` and `/* */` comments in the Vimspector config are supported: they are ignored while reading and, when Vim is built with `+python3`, carried over when the plugin rewrites the file.
 
 ## Extensions
 

--- a/autoload/utils/config/vimspector.vim
+++ b/autoload/utils/config/vimspector.vim
@@ -7,9 +7,62 @@ function! s:getVimspectorConfig() abort
     return getcwd() . '/.vimspector.json'
 endfunction
 
+" Strips '//' line comments and '/* */' block comments (both allowed by
+" vimspector) so that json_decode can parse the config. Comment markers inside
+" JSON strings are preserved, so values like URLs or Windows paths are kept
+" intact. Block comments may span multiple lines.
+function! s:stripJsonComments(lines) abort
+    let l:result = []
+    let l:in_string = 0
+    let l:escaped = 0
+    let l:in_block = 0
+    for l:line in a:lines
+        let l:out = ''
+        let l:i = 0
+        let l:len = strlen(l:line)
+        while l:i < l:len
+            let l:ch = l:line[l:i]
+            if l:in_block
+                if l:ch ==# '*' && l:i + 1 < l:len && l:line[l:i + 1] ==# '/'
+                    let l:in_block = 0
+                    let l:i += 2
+                    continue
+                endif
+                let l:i += 1
+                continue
+            elseif l:in_string
+                let l:out .= l:ch
+                if l:escaped
+                    let l:escaped = 0
+                elseif l:ch ==# '\'
+                    let l:escaped = 1
+                elseif l:ch ==# '"'
+                    let l:in_string = 0
+                endif
+            elseif l:ch ==# '"'
+                let l:in_string = 1
+                let l:out .= l:ch
+            elseif l:ch ==# '/' && l:i + 1 < l:len && l:line[l:i + 1] ==# '/'
+                " The rest of the line is a comment
+                break
+            elseif l:ch ==# '/' && l:i + 1 < l:len && l:line[l:i + 1] ==# '*'
+                let l:in_block = 1
+                let l:i += 2
+                continue
+            else
+                let l:out .= l:ch
+            endif
+            let l:i += 1
+        endwhile
+        call add(l:result, l:out)
+    endfor
+    return l:result
+endfunction
+
 function! s:readVimspectorConfig() abort
     try
-        return json_decode(join(readfile(s:getVimspectorConfig()), ''))
+        let l:lines = s:stripJsonComments(readfile(s:getVimspectorConfig()))
+        return json_decode(join(l:lines, ''))
     catch
         call utils#common#Warning('Exception reading vimspector config: ' . v:exception)
         return {}
@@ -17,13 +70,256 @@ function! s:readVimspectorConfig() abort
 endfunction
 
 function! s:writeJson(json_content) abort
-    " Apply pretty format if vim supports python3 (vimspector requires py3)
+    " Apply pretty format if vim supports python3 (vimspector requires py3).
+    " The python3 branch keeps the original key order and carries over '//' and
+    " '/* */' comments from the previous file content, attaching each comment to
+    " the JSON path (including array indices) of the key it belongs to.
     if has('python3')
 py3 << EOF
 import json
+import os
 import vim
-with open(vim.eval('s:getVimspectorConfig()'), 'w') as vimspector_json:
-    sorted_content = json.dump(vim.eval('a:json_content'), vimspector_json, indent=4, sort_keys=True)
+from collections import OrderedDict
+
+
+# Scan text line by line, tracking the JSON path. For every line it reports the
+# stripped code, the comment (if any), the paths of the keys declared on it and
+# the paths of the containers whose closing bracket appears on it. Paths are
+# tuples of dict keys and array indices, so every position is unique.
+def _scan_lines(text):
+    stack = []
+    pending = None
+    last_str = None
+    in_string = escaped = in_block = False
+    cur = []
+    results = []
+    for raw in text.split('\n'):
+        block_start = in_block
+        code = []
+        comment = []
+        keys = []
+        closes = []
+        i, n = 0, len(raw)
+        while i < n:
+            ch = raw[i]
+            if in_block:
+                if ch == '*' and i + 1 < n and raw[i + 1] == '/':
+                    comment.append('*/')
+                    in_block = False
+                    i += 2
+                    continue
+                comment.append(ch)
+                i += 1
+                continue
+            if in_string:
+                code.append(ch)
+                if escaped:
+                    escaped = False
+                    cur.append(ch)
+                elif ch == '\\':
+                    escaped = True
+                    cur.append(ch)
+                elif ch == '"':
+                    in_string = False
+                    last_str = ''.join(cur)
+                else:
+                    cur.append(ch)
+                i += 1
+                continue
+            if ch == '"':
+                in_string = True
+                cur = []
+                code.append(ch)
+                i += 1
+                continue
+            if ch == '/' and i + 1 < n and raw[i + 1] == '/':
+                comment.append(raw[i:])
+                break
+            if ch == '/' and i + 1 < n and raw[i + 1] == '*':
+                in_block = True
+                comment.append('/*')
+                i += 2
+                continue
+            if ch in '{[':
+                parent = stack[-1] if stack else None
+                if parent is not None and parent['type'] == 'array':
+                    component = parent['idx']
+                elif pending is not None:
+                    component = pending
+                else:
+                    component = None
+                parent_path = parent['path'] if parent is not None else ()
+                path = parent_path + (component,) if component is not None else parent_path
+                stack.append({'type': 'dict' if ch == '{' else 'array',
+                              'path': path, 'idx': 0})
+                pending = None
+                last_str = None
+                code.append(ch)
+                i += 1
+                continue
+            if ch in '}]':
+                if stack:
+                    closes.append(stack.pop()['path'])
+                pending = None
+                last_str = None
+                code.append(ch)
+                i += 1
+                continue
+            if ch == ':':
+                if last_str is not None:
+                    parent_path = stack[-1]['path'] if stack else ()
+                    pending = last_str
+                    keys.append(parent_path + (last_str,))
+                    last_str = None
+                code.append(ch)
+                i += 1
+                continue
+            if ch == ',':
+                last_str = None
+                if stack and stack[-1]['type'] == 'array':
+                    stack[-1]['idx'] += 1
+                code.append(ch)
+                i += 1
+                continue
+            code.append(ch)
+            i += 1
+        results.append({
+            'raw': raw,
+            'code': ''.join(code).strip(),
+            'comment': ''.join(comment).strip(),
+            'keys': keys,
+            'closes': closes,
+            'block_start': block_start,
+        })
+    return results
+
+
+# Strip '//' and '/* */' comments, reusing the single tokenizer in _scan_lines
+# so the read and write paths can never disagree on what a comment is.
+def _strip_json_comments(text):
+    return '\n'.join(line['code'] for line in _scan_lines(text))
+
+
+def _flush_buffered(buffered):
+    # Drop blank lines that trail the group right before its anchor.
+    while buffered and not buffered[-1].strip():
+        buffered.pop()
+    return buffered
+
+
+def _extract_comments(text):
+    # leading[path]        comments printed above the key's line
+    # inline[path]         comment appended to the key's line
+    # trailing[container]  comments printed just before the container's close
+    # close_inline[cont]   comment appended to the container's closing line
+    leading = {}
+    inline = {}
+    trailing = {}
+    close_inline = {}
+    buffered = []
+    for line in _scan_lines(text):
+        if line['keys']:
+            if _flush_buffered(buffered):
+                leading.setdefault(line['keys'][0], []).extend(buffered)
+            buffered = []
+            if line['comment']:
+                inline[line['keys'][-1]] = line['comment']
+        elif line['closes']:
+            # A structural line (closing bracket). Comments buffered before it
+            # belong to the container being closed, not to the next sibling key.
+            if _flush_buffered(buffered):
+                trailing.setdefault(line['closes'][0], []).extend(buffered)
+            buffered = []
+            if line['comment']:
+                close_inline[line['closes'][-1]] = line['comment']
+        elif line['comment'] and not line['code']:
+            # Keep the original line (with its leading whitespace) so the
+            # relative indentation can be restored on write.
+            buffered.append(line['raw'].rstrip())
+        elif not line['code'] and not line['comment'] and (line['block_start'] or buffered):
+            # Blank line inside a commented out block: keep the formatting
+            buffered.append('')
+    return leading, inline, trailing, close_inline
+
+
+def _emit_group(out, group, indent):
+    # Drop the common leading whitespace and re-indent the whole group to the
+    # anchor, keeping the relative indentation between its lines. Blank lines are
+    # emitted empty and ignored when measuring the base.
+    base = min((len(c) - len(c.lstrip()) for c in group if c.strip()), default=0)
+    for comment in group:
+        out.append(indent + comment[base:] if comment.strip() else '')
+
+
+def _reinsert_comments(body, leading, inline, trailing, close_inline):
+    if not (leading or inline or trailing or close_inline):
+        return body
+    out = []
+    for line in _scan_lines(body):
+        raw = line['raw']
+        indent = raw[:len(raw) - len(raw.lstrip())]
+        if line['closes'] and line['closes'][0] in trailing:
+            # Trailing comments sit inside the container, one level deeper than
+            # its closing bracket.
+            _emit_group(out, trailing[line['closes'][0]], indent + '    ')
+        if line['keys'] and line['keys'][0] in leading:
+            _emit_group(out, leading[line['keys'][0]], indent)
+        suffix = ''
+        if line['keys'] and line['keys'][-1] in inline:
+            suffix = ' ' + inline[line['keys'][-1]]
+        elif line['closes'] and line['closes'][-1] in close_inline:
+            suffix = ' ' + close_inline[line['closes'][-1]]
+        out.append(raw + suffix)
+    return '\n'.join(out)
+
+
+# Rebuild the object taking values from the freshly generated config while
+# keeping the key order of the previous file; brand new keys are appended in a
+# stable sorted order so a fresh config is written deterministically.
+def _merge_order(new_value, old_value):
+    if isinstance(new_value, dict):
+        old_value = old_value if isinstance(old_value, dict) else {}
+        result = OrderedDict()
+        for key in old_value:
+            if key in new_value:
+                result[key] = _merge_order(new_value[key], old_value[key])
+        for key in sorted(k for k in new_value if k not in result):
+            result[key] = _merge_order(new_value[key], None)
+        return result
+    return new_value
+
+
+def _warn(message):
+    vim.command("call utils#common#Warning('" + message.replace("'", "''") + "')")
+
+
+_cfg_path = vim.eval('s:getVimspectorConfig()')
+_new_obj = vim.eval('a:json_content')
+_old_raw = ''
+if os.path.exists(_cfg_path):
+    try:
+        with open(_cfg_path, encoding='utf-8') as _f:
+            _old_raw = _f.read()
+    except Exception as _e:
+        _warn('Could not read existing vimspector config: ' + str(_e))
+
+try:
+    _old_obj = (json.loads(_strip_json_comments(_old_raw), object_pairs_hook=OrderedDict)
+                if _old_raw.strip() else None)
+except Exception:
+    _old_obj = None
+
+# ensure_ascii=False keeps non-ASCII keys/values literal so they match the
+# comment paths extracted from the original (UTF-8) file.
+_body = json.dumps(_merge_order(_new_obj, _old_obj), indent=4, ensure_ascii=False)
+
+try:
+    _body = _reinsert_comments(_body, *_extract_comments(_old_raw))
+except Exception as _e:
+    _warn('Could not preserve comments in vimspector config: ' + str(_e))
+
+with open(_cfg_path, 'w', encoding='utf-8') as _f:
+    _f.write(_body)
 EOF
     else " nvim doesn't have python3
         silent call writefile([json_encode(a:json_content)], s:getVimspectorConfig())

--- a/test/tests/integration/vimspector.vader
+++ b/test/tests/integration/vimspector.vader
@@ -65,6 +65,240 @@ Execute ([Vimspector] Read correct vimspector config):
         Assert has_key(config['configurations'], 'something_else'), "Config should have something_else"
     endif
 
+Execute ([Vimspector] Read vimspector config with comments):
+    if !has('win32')
+        Assert !filereadable(".vimspector.json"), "Vimspector config should not be generated"
+        " Create config containing '//' and '/* */' comments (allowed by vimspector)
+        silent call writefile( [
+            \ '{',
+            \ '    "configurations": {',
+            \ '        // a whole-line comment',
+            \ '        /* a block comment',
+            \ '           spanning several lines */',
+            \ '        "test_app": {',
+            \ '            "adapter": "CodeLLDB", // an inline comment',
+            \ '            "configuration": {',
+            \ '                "type": "cppdbg", /* inline block */',
+            \ '                "request": "launch",',
+            \ '                "program": "http://example.com/test_app",',
+            \ '                "args": ["1", "2", "3", "4"],',
+            \ '                "cwd": "${workspaceRoot}"',
+            \ '            }',
+            \ '        }',
+            \ '    }',
+            \ '}',
+            \ ], '.vimspector.json')
+
+        Assert filereadable(".vimspector.json"), "Vimspector config should be generated"
+        let config = utils#config#vimspector#updateConfig({})
+        Assert has_key(config, 'configurations'), "Config should have configurations"
+        Assert has_key(config['configurations'], 'test_app'), "Config should have test_app"
+        Assert has_key(config['configurations']['test_app'], 'configuration'), "Test_app should have configuration"
+        " Comment markers inside a string (the URL) must be preserved
+        AssertEqual config['configurations']['test_app']['configuration']['program'], "http://example.com/test_app"
+        AssertEqual len(config['configurations']['test_app']['configuration']['args']), 4
+    endif
+
+Execute ([Vimspector] Read vimspector config with a commented out section):
+    if !has('win32')
+        Assert !filereadable(".vimspector.json"), "Vimspector config should not be generated"
+        " A whole target commented out with a block comment (containing '//'
+        " comments inside), another target commented out line by line, and a
+        " value that merely looks like a comment
+        silent call writefile( [
+            \ '{',
+            \ '    "configurations": {',
+            \ '        "test_app": {',
+            \ '            "adapter": "CodeLLDB",',
+            \ '            "configuration": {',
+            \ '                "type": "cppdbg",',
+            \ '                "request": "launch",',
+            \ '                "program": "${workspaceRoot}/test_app",',
+            \ '                "args": ["1", "2", "3", "4"],',
+            \ '                "cwd": "${workspaceRoot}"',
+            \ '            }',
+            \ '        },',
+            \ '        /*',
+            \ '        "disabled_block": {',
+            \ '            "adapter": "CodeLLDB", // adapter comment inside the block',
+            \ '            "configuration": {',
+            \ '                // program below is intentionally disabled',
+            \ '                "program": "http://example.com/disabled",',
+            \ '                "args": ["should", "not", "appear"]',
+            \ '            }',
+            \ '        },',
+            \ '        */',
+            \ '        // "disabled_line": {',
+            \ '        //     "adapter": "CodeLLDB", // inline within a line-commented block',
+            \ '        //     "configuration": { "program": "nope://x" }',
+            \ '        // },',
+            \ '        "keep_slashes": {',
+            \ '            "adapter": "CodeLLDB",',
+            \ '            "configuration": {',
+            \ '                "type": "cppdbg",',
+            \ '                "request": "launch",',
+            \ '                "program": "/*literal*/ // not a comment",',
+            \ '                "cwd": "${workspaceRoot}"',
+            \ '            }',
+            \ '        }',
+            \ '    }',
+            \ '}',
+            \ ], '.vimspector.json')
+
+        Assert filereadable(".vimspector.json"), "Vimspector config should be generated"
+        let config = utils#config#vimspector#updateConfig({})
+        Assert has_key(config, 'configurations'), "Config should have configurations"
+        " Active targets are parsed
+        Assert has_key(config['configurations'], 'test_app'), "Config should have test_app"
+        Assert has_key(config['configurations'], 'keep_slashes'), "Config should have keep_slashes"
+        AssertEqual len(config['configurations']['test_app']['configuration']['args']), 4
+        " Commented out targets must be ignored
+        Assert !has_key(config['configurations'], 'disabled_block'), "Block-commented target must be ignored"
+        Assert !has_key(config['configurations'], 'disabled_line'), "Line-commented target must be ignored"
+        " Comment markers inside a string value must survive untouched
+        AssertEqual config['configurations']['keep_slashes']['configuration']['program'], "/*literal*/ // not a comment"
+    endif
+
+Execute ([Vimspector] Preserve comments when writing config):
+    if !has('win32') && has('python3')
+        Assert !filereadable(".vimspector.json"), "Vimspector config should not be generated"
+        silent call writefile( [
+            \ '{',
+            \ '    "configurations": {',
+            \ '        // leading comment for test_app',
+            \ '        "test_app": {',
+            \ '            "adapter": "CodeLLDB", // inline adapter comment',
+            \ '            "configuration": {',
+            \ '                "type": "cppdbg",',
+            \ '                "request": "launch",',
+            \ '                "program": "${workspaceRoot}/test_app",',
+            \ '                "args": ["1", "2"],',
+            \ '                "cwd": "${workspaceRoot}"',
+            \ '            }',
+            \ '        }',
+            \ '    }',
+            \ '}',
+            \ ], '.vimspector.json')
+
+        " A non-empty config triggers a write back to disk
+        let config = utils#config#vimspector#updateConfig({'test_app': {'app': 'new_bin/test_app', 'args': ['a']}})
+        AssertEqual config['configurations']['test_app']['configuration']['program'], "new_bin/test_app"
+
+        let written = map(readfile('.vimspector.json'), 'trim(v:val)')
+        Assert index(written, '// leading comment for test_app') >= 0, "Leading comment should be preserved"
+        Assert index(written, '"adapter": "CodeLLDB", // inline adapter comment') >= 0, "Inline comment should be preserved"
+        " The written config must still be valid JSON (comments stripped on read)
+        let reread = utils#config#vimspector#updateConfig({})
+        AssertEqual reread['configurations']['test_app']['configuration']['program'], "new_bin/test_app"
+    endif
+
+Execute ([Vimspector] Preserve a commented out section when writing config):
+    if !has('win32') && has('python3')
+        Assert !filereadable(".vimspector.json"), "Vimspector config should not be generated"
+        silent call writefile( [
+            \ '{',
+            \ '    "configurations": {',
+            \ '        "test_app": {',
+            \ '            "adapter": "CodeLLDB",',
+            \ '            "configuration": {',
+            \ '                "type": "cppdbg",',
+            \ '                "request": "launch",',
+            \ '                "program": "${workspaceRoot}/test_app",',
+            \ '                "args": ["1", "2"],',
+            \ '                "cwd": "${workspaceRoot}"',
+            \ '            }',
+            \ '        },',
+            \ '        /*',
+            \ '        "disabled_block": {',
+            \ '            "adapter": "CodeLLDB", // adapter comment inside the block',
+            \ '',
+            \ '            "configuration": { "program": "http://example.com/disabled" }',
+            \ '        },',
+            \ '        */',
+            \ '        // "disabled_line": { "adapter": "CodeLLDB" },',
+            \ '        "keep_slashes": {',
+            \ '            "adapter": "CodeLLDB",',
+            \ '            "configuration": {',
+            \ '                "type": "cppdbg",',
+            \ '                "request": "launch",',
+            \ '                "program": "${workspaceRoot}/test_app",',
+            \ '                "cwd": "${workspaceRoot}"',
+            \ '            }',
+            \ '        }',
+            \ '    }',
+            \ '}',
+            \ ], '.vimspector.json')
+
+        " A non-empty config triggers a write back to disk
+        let config = utils#config#vimspector#updateConfig({'test_app': {'app': 'new_bin/test_app', 'args': ['a']}})
+        AssertEqual config['configurations']['test_app']['configuration']['program'], "new_bin/test_app"
+
+        " Commented out sections are carried over as text
+        let raw_lines = readfile('.vimspector.json')
+        let written = join(raw_lines, "\n")
+        Assert stridx(written, 'disabled_block') >= 0, "Block-commented section should be preserved"
+        Assert stridx(written, 'disabled_line') >= 0, "Line-commented section should be preserved"
+        " The relative indentation inside the block is kept (the block base is
+        " aligned to the key at 8 spaces, the nested line stays 4 spaces deeper)
+        let adapter_idx = index(raw_lines, '            "adapter": "CodeLLDB", // adapter comment inside the block')
+        Assert adapter_idx >= 0, "Relative indentation inside the block should be preserved"
+        " The blank line inside the block keeps the block formatting intact
+        AssertEqual raw_lines[adapter_idx + 1], '', "Blank line inside the block should be preserved"
+
+        " The rewritten file must still parse and keep ignoring commented out targets
+        let reread = utils#config#vimspector#updateConfig({})
+        Assert has_key(reread['configurations'], 'test_app'), "test_app should still be present"
+        Assert has_key(reread['configurations'], 'keep_slashes'), "keep_slashes should still be present"
+        Assert !has_key(reread['configurations'], 'disabled_block'), "Block-commented target must stay commented after rewrite"
+        Assert !has_key(reread['configurations'], 'disabled_line'), "Line-commented target must stay commented after rewrite"
+    endif
+
+Execute ([Vimspector] Preserve structural-line and trailing comments when writing config):
+    if !has('win32') && has('python3')
+        Assert !filereadable(".vimspector.json"), "Vimspector config should not be generated"
+        silent call writefile( [
+            \ '{',
+            \ '    "configurations": {',
+            \ '        "test_app": {',
+            \ '            "adapter": "CodeLLDB",',
+            \ '            "configuration": {',
+            \ '                "type": "cppdbg",',
+            \ '                "request": "launch",',
+            \ '                "program": "${workspaceRoot}/test_app",',
+            \ '                "args": ["1", "2"],',
+            \ '                "cwd": "${workspaceRoot}"',
+            \ '            }',
+            \ '        }, // trailing comment after test_app',
+            \ '        "other_app": {',
+            \ '            "adapter": "CodeLLDB",',
+            \ '            "configuration": {',
+            \ '                "program": "${workspaceRoot}/other"',
+            \ '            }',
+            \ '        }',
+            \ '        // note at the end of configurations',
+            \ '    }',
+            \ '}',
+            \ ], '.vimspector.json')
+
+        " A non-empty config triggers a write back to disk
+        let config = utils#config#vimspector#updateConfig({'test_app': {'app': 'new_bin/test_app', 'args': ['a']}})
+        AssertEqual config['configurations']['test_app']['configuration']['program'], "new_bin/test_app"
+
+        let written = map(readfile('.vimspector.json'), 'trim(v:val)')
+        " A comment sharing a line with a closing brace must be kept on that line
+        Assert index(written, '}, // trailing comment after test_app') >= 0, "Structural-line comment should be preserved"
+        " A comment after the last member must stay in that object, not migrate
+        let note_idx = index(written, '// note at the end of configurations')
+        let other_idx = index(written, '"other_app": {')
+        Assert note_idx >= 0, "Trailing comment should be preserved"
+        Assert note_idx > other_idx, "Trailing comment should stay inside configurations after other_app"
+
+        " The rewritten file must still parse and keep both targets
+        let reread = utils#config#vimspector#updateConfig({})
+        Assert has_key(reread['configurations'], 'test_app'), "test_app should still be present"
+        Assert has_key(reread['configurations'], 'other_app'), "other_app should still be present"
+    endif
+
 Execute ([Vimspector] Change correct vimspector config):
     if !has('win32')
         Assert !filereadable(".vimspector.json"), "Vimspector config should not be generated"
@@ -247,8 +481,15 @@ Execute ([Vimspector] Read vimspector config containing backslashes):
         Assert has_key(config['configurations'], 'with_backslashes' ), 'Config should have the target with_backslashes'
         AssertEqual config['configurations']['with_backslashes']['configuration']['args'], ["--gtest_filter=\"Hello\""]
 
-        if !has('nvim') && !has('win32')
-            AssertEqual trim(readfile('.vimspector.json')[32]), '"--gtest_filter=\"Hello\""'
+        if !has('nvim') && !has('win32') && has('python3')
+            let written = map(readfile('.vimspector.json'), 'trim(v:val)')
+            " The escaped arg must survive verbatim on its own line ...
+            let filter_idx = index(written, '"--gtest_filter=\"Hello\""')
+            Assert filter_idx >= 0, "Backslashes should be preserved in the written config"
+            " ... and it must stay inside the with_backslashes target rather than
+            " migrate to another target or nesting level on rewrite.
+            let wb_idx = index(written, '"with_backslashes": {')
+            Assert wb_idx >= 0 && filter_idx > wb_idx, "Escaped arg should live inside the with_backslashes target"
         endif
     endif
 


### PR DESCRIPTION
This patch is related to the issue #164.

Harden the python3 comment carry-over path so user comments are no longer dropped, duplicated or moved to the wrong scope when the config is rewritten:

- Track a full container stack with array indices, so JSON paths are unique and repeated keys inside arrays no longer collide.
- Reattach trailing comments before a container's closing bracket and comments that share a line with a closing brace, and keep them in scope instead of migrating to the next sibling key.
- Use ensure_ascii=False / utf-8 so non-ASCII keys still match their comments.
- Preserve existing key order but append brand-new keys sorted, restoring deterministic output lost when sort_keys was dropped.
- Wrap the existing-file read and comment reinsertion so failures warn instead of silently dropping comments or aborting :CMakeRun.
- Derive _strip_json_comments from the single _scan_lines tokenizer.

Strengthen the backslash write test to assert the escaped arg stays inside its target, and add coverage for structural-line and trailing comments.